### PR TITLE
prove deterministic demo bootstrap contract

### DIFF
--- a/internal/demo/spec_test.go
+++ b/internal/demo/spec_test.go
@@ -1,0 +1,63 @@
+package demo
+
+import "testing"
+
+func TestSpecIsDeterministicAcrossCalls(t *testing.T) {
+	t.Parallel()
+
+	first := Spec()
+	second := Spec()
+
+	if first.Customer.ID != second.Customer.ID || first.Customer.Name != second.Customer.Name || first.Customer.SMSNumber != second.Customer.SMSNumber {
+		t.Fatal("expected demo customer spec to stay stable across calls")
+	}
+
+	if len(first.Stores) != 2 {
+		t.Fatalf("expected 2 demo stores, got %d", len(first.Stores))
+	}
+	if len(second.Stores) != len(first.Stores) {
+		t.Fatalf("expected stable store count, got %d and %d", len(first.Stores), len(second.Stores))
+	}
+
+	for i := range first.Stores {
+		left := first.Stores[i]
+		right := second.Stores[i]
+
+		if left.ID != right.ID || left.Name != right.Name || left.Location != right.Location || left.Participating != right.Participating {
+			t.Fatalf("expected store %d to be stable across calls", i)
+		}
+		if len(left.Products) != len(right.Products) {
+			t.Fatalf("expected stable product count for store %s", left.ID)
+		}
+
+		for j := range left.Products {
+			lp := left.Products[j]
+			rp := right.Products[j]
+
+			if lp != rp {
+				t.Fatalf("expected product %d in store %s to be stable across calls", j, left.ID)
+			}
+		}
+	}
+}
+
+func TestSpecReturnsFreshCopies(t *testing.T) {
+	t.Parallel()
+
+	first := Spec()
+	first.Customer.Name = "Mutated"
+	first.Stores[0].Name = "Changed Store"
+	first.Stores[0].Products[0].Name = "Changed Product"
+
+	second := Spec()
+
+	if second.Customer.Name != "Demo Shopper" {
+		t.Fatalf("expected fresh customer copy, got %q", second.Customer.Name)
+	}
+	if second.Stores[0].Name != "Fresh Harvest Grocers" {
+		t.Fatalf("expected fresh store copy, got %q", second.Stores[0].Name)
+	}
+	if second.Stores[0].Products[0].Name != "Bananas" {
+		t.Fatalf("expected fresh product copy, got %q", second.Stores[0].Products[0].Name)
+	}
+}

--- a/search/internal/grpc/demo_bootstrap_test.go
+++ b/search/internal/grpc/demo_bootstrap_test.go
@@ -1,0 +1,63 @@
+package grpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/owezzy/soko-bora-mngt-system/internal/demo"
+	"github.com/owezzy/soko-bora-mngt-system/search/internal/application"
+	"github.com/owezzy/soko-bora-mngt-system/search/internal/models"
+	"github.com/owezzy/soko-bora-mngt-system/search/searchpb"
+)
+
+func TestGetDemoBootstrapReturnsDeterministicSeedContext(t *testing.T) {
+	t.Parallel()
+
+	svc := server{app: stubApplication{bootstrap: demo.Spec()}}
+
+	resp, err := svc.GetDemoBootstrap(context.Background(), &searchpb.GetDemoBootstrapRequest{})
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	if resp.GetCustomer().GetId() != demo.Spec().Customer.ID {
+		t.Fatalf("expected demo customer id %q, got %q", demo.Spec().Customer.ID, resp.GetCustomer().GetId())
+	}
+	if len(resp.GetStores()) != len(demo.Spec().Stores) {
+		t.Fatalf("expected %d stores, got %d", len(demo.Spec().Stores), len(resp.GetStores()))
+	}
+
+	productCount := 0
+	for _, store := range demo.Spec().Stores {
+		productCount += len(store.Products)
+	}
+	if len(resp.GetProducts()) != productCount {
+		t.Fatalf("expected %d demo products, got %d", productCount, len(resp.GetProducts()))
+	}
+
+	firstStore := demo.Spec().Stores[0]
+	firstProduct := firstStore.Products[0]
+
+	if resp.GetStores()[0].GetId() != firstStore.ID || resp.GetStores()[0].GetName() != firstStore.Name {
+		t.Fatal("expected first demo store to match bootstrap spec")
+	}
+	if resp.GetProducts()[0].GetId() != firstProduct.ID || resp.GetProducts()[0].GetStoreId() != firstStore.ID || resp.GetProducts()[0].GetStoreName() != firstStore.Name {
+		t.Fatal("expected first demo product to carry store context from bootstrap spec")
+	}
+}
+
+type stubApplication struct {
+	bootstrap application.DemoBootstrap
+}
+
+func (s stubApplication) SearchOrders(context.Context, application.SearchOrders) ([]*models.Order, error) {
+	panic("unused")
+}
+
+func (s stubApplication) GetOrder(context.Context, application.GetOrder) (*models.Order, error) {
+	panic("unused")
+}
+
+func (s stubApplication) GetDemoBootstrap(context.Context) (application.DemoBootstrap, error) {
+	return s.bootstrap, nil
+}


### PR DESCRIPTION
## Summary
- add regression tests that prove `internal/demo.Spec()` stays deterministic across calls while returning fresh copies
- add gRPC bootstrap coverage to verify the search service exposes the seeded demo customer, stores, and products with stable store context
- verify the search demo bootstrap path with targeted tests and `go build ./search/...`