### PR TITLE
Add seeded kiosk happy-path proof

### DIFF
--- a/docs/monolith-happy-path.md
+++ b/docs/monolith-happy-path.md
@@ -30,9 +30,21 @@ Start the monolith and infrastructure first, then run:
 go test -tags e2e ./testing/e2e/... -mono
 ```
 
+For the single seeded kiosk proof that now serves as the minimum milestone check, run:
+
+```bash
+go test -tags e2e ./testing/e2e/... -run TestEndToEnd -mono -godog.tags=@demo-milestone-proof
+```
+
+## Canonical seeded kiosk proof
+
+The scenario `Seeded kiosk happy path completes end to end` in `testing/e2e/features/kiosk/shopping.feature` is the canonical proof for the monolith-first kiosk milestone.
+
+It is the one scenario intended to prove that the seeded kiosk demo is reproducible from startup state through final backend completion.
+
 ## What the proof covers
 
-The seeded scenario in `testing/e2e/features/orders/processing.feature` verifies that:
+The seeded kiosk proof verifies that:
 
 1. a seeded demo customer can start a basket
 2. seeded demo products can be added and checked out

--- a/testing/e2e/features/kiosk/shopping.feature
+++ b/testing/e2e/features/kiosk/shopping.feature
@@ -5,7 +5,8 @@ Feature: Kiosk Shopping
     Given I start a new basket for the seeded demo customer
     Then the basket was started
 
-  Scenario: Seeded kiosk checkout creates a live order projection
+  @demo-milestone-proof
+  Scenario: Seeded kiosk happy path completes end to end
     Given I start a new basket for the seeded demo customer
     And the basket was started
     And I add the seeded demo items
@@ -16,6 +17,12 @@ Feature: Kiosk Shopping
     When I check out the basket
     Then the basket is checked out
     And the checked out basket eventually becomes an order
+    And an order exists for the checked out basket
+    And the order is visible through the ordering API
+    And the order belongs to the current customer
+    And the order references the authorized payment
+    And the order contains the basket items
+    And the order status is "approved"
     And the depot shopping list exists for the order
     And the shopping list status is "available"
     When I assign the shopping list to bot "demo-bot-001"
@@ -26,3 +33,9 @@ Feature: Kiosk Shopping
     And an invoice exists for the checked out basket
     And a "ready" notification exists for the order
     And the search projection status is "Ready For Pickup"
+    When I pay the invoice for the checked out basket
+    Then the invoice status is "paid"
+    And the order status is "completed"
+    And the order has an invoice id
+    And a "created" notification exists for the order
+    And the search projection status is "Completed"


### PR DESCRIPTION
## Summary
- promote one seeded kiosk scenario as the canonical demo milestone proof
- align the kiosk proof scenario with the proven happy-path order/depot/payment sequence
- document the exact focused command for running the milestone proof