### PR TITLE
Rewrite README as a runnable monolith demo guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,245 +1,224 @@
-<!-- Improved compatibility of back to top link: See: https://github.com/othneildrew/Best-README-Template/pull/73 -->
-<a name="readme-top"></a>
-<!--
-*** Thanks for checking out the Best-README-Template. If you have a suggestion
-*** that would make this better, please fork the repo and create a pull request
-*** or simply open an issue with the tag "enhancement".
-*** Don't forget to give the project a star!
-*** Thanks again! Now go create something AMAZING! :D
--->
+# MallBots monolith demo guide
 
-<!-- PROJECT SHIELDS -->
-<!--
-*** I'm using markdown "reference style" links for readability.
-*** Reference links are enclosed in brackets [ ] instead of parentheses ( ).
-*** See the bottom of this document for the declaration of the reference variables
-*** for contributors-url, forks-url, etc. This is an optional, concise syntax you may use.
-*** https://www.markdownguide.org/basic-syntax/#reference-style-links
--->
-[![Contributors][contributors-shield]][contributors-url]
-[![Forks][forks-shield]][forks-url]
-[![Stargazers][stars-shield]][stars-url]
-[![Issues][issues-shield]][issues-url]
-[![MIT License][license-shield]][license-url]
-[![LinkedIn][linkedin-shield]][linkedin-url]
+MallBots is an event-driven retail automation demo built as a modular monolith in Go with an Angular kiosk frontend. The current milestone is a monolith-first kiosk experience backed by real domain services for baskets, customers, stores, payments, ordering, depot, notifications, and search.
 
-<!-- PROJECT LOGO -->
-<br />
-<div align="center">
-  <a href="https://github.com/owezzy/soko-bora-mngt-system">
-    <img src="client/soko-bora-web-app/public/images/logo/logo.svg" alt="Logo" width="80" height="80">
-  </a>
+This README is the runnable guide for that milestone: how to boot the monolith, how deterministic demo data is prepared, how to use the kiosk flow, and how to verify the happy path.
 
-<h3 align="center">MallBots</h3>
+## What this demo proves
 
-  <p align="center">
-We have developed incredible robots to save the people's time shopping at the mall. Customers will now have access to a kiosk that would facilitate the selection of items from available stores that customers do not wish to visit. After completing their selections, the customer is free to do other shopping or directly visit the depot and wait for their items to be brought in by robots. The customer may pay when they arrive at the depot or may choose to wait for all items to arrive before doing so. After both are done, the transaction is complete, and the customer takes their items and goes on their merry way.
-    <br />
-    <a href="https://github.comowezzy/soko-bora-mngt-system"><strong>Explore the docs »</strong></a>
-    <br />
-    <br />
-    <a href="https://github.com/owezzy/soko-bora-mngt-system">View Demo</a>
-    ·
-    <a href="https://github.com/owezzy/soko-bora-mngt-system/issues">Report Bug</a>
-    ·
-    <a href="https://github.com/owezzy/soko-bora-mngt-system/issues">Request Feature</a>
-  </p>
-</div>
+The seeded monolith demo exercises a real customer journey:
 
-<!-- TABLE OF CONTENTS -->
-<details>
-  <summary>Table of Contents</summary>
-  <ol>
-    <li>
-      <a href="#about-the-project">About The Project</a>
-      <ul>
-        <li><a href="#built-with">Built With</a></li>
-      </ul>
-    </li>
-    <li>
-      <a href="#getting-started">Getting Started</a>
-      <ul>
-        <li><a href="#prerequisites">Prerequisites</a></li>
-        <li><a href="#installation">Installation</a></li>
-      </ul>
-    </li>
-    <li><a href="#usage">Usage</a></li>
-    <li><a href="#roadmap">Roadmap</a></li>
-    <li><a href="#contributing">Contributing</a></li>
-    <li><a href="#license">License</a></li>
-    <li><a href="#contact">Contact</a></li>
-    <li><a href="#acknowledgments">Acknowledgments</a></li>
-  </ol>
-</details>
+- browse a seeded store catalog
+- add products to a live basket
+- authorize payment and submit checkout
+- create an order through the backend saga
+- advance fulfillment and payment to final completion in automated proof runs
+- observe order state through the live backend search projection
 
-<!-- ABOUT THE PROJECT -->
-## About The Project
+The seeded demo data comes from `internal/demo/spec.go` and is intended to be reproducible.
 
-[![Product Name Screen Shot][product-screenshot]](https://example.com)
-High level view of the application components.
+## Repository layout for the demo
 
-MallBots is a retail automation platform built around a futuristic shopping experience. Customers can
-use kiosk applications to build baskets without visiting each store, authorize payment, and check out
-while autonomous shopper bots handle fulfillment behind the scenes. This repository contains the
-backend services and frontend clients that power that flow.
+- `cmd/mallbots/main.go` - monolith entrypoint
+- `client/soko-bora-web-app/` - Angular kiosk/admin frontend
+- `docs/monolith-happy-path.md` - focused proof notes for the seeded happy path
+- `testing/e2e/` - seeded end-to-end verification suite
+- `docker-compose.yml` - monolith, infra, and observability services
+- `docker/.env` - monolith container environment values
 
-## Application services
-The core application services include Orders, Stores, Payments, Depot, Customers, Baskets, Search,
-Notifications, and the `cosec` saga coordinator. They communicate through domain and integration
-events, publish state changes through NATS JetStream, and expose gRPC and REST interfaces for the
-gateway and client layers.
+## Prerequisites
 
-## API gateway services
-The gateway layer is intended to support multiple client experiences: a REST API for customer kiosks,
-an administrative interface for staff workflows, and automation-friendly APIs for robot clients. The
-project follows a Backend for Frontend (BFF) approach so each client surface can evolve around its own
-data and interaction needs while reusing the same underlying domain services.
+You need:
 
-## Clients
-The expected clients in the MallBots ecosystem are:
+- Docker + Docker Compose
+- Go 1.24+
+- Node.js + npm
 
-- Customer kiosks placed near mall entrances for fast self-service ordering
-- An administrative web application for staff to manage stores, fulfill pickups, and take payment
-- Shopper bot clients that perform autonomous shopping tasks for customers
+## Boot the monolith demo
 
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
+From the repository root:
 
-### Built With
+```bash
+make soko-bora
+```
 
-* [![Angular][Angular.io]][Angular-url]
-* [![Golang]][Golang-url]
-* [![Graphql]][Graphql-url]
-* [![aws]][aws-url]
-* [![Git]][git]
+That starts the monolith profile from `docker-compose.yml`, including:
 
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
+- monolith app on `http://localhost:8080`
+- PostgreSQL on `localhost:5432`
+- NATS JetStream on `localhost:4222`
+- Jaeger UI on `http://localhost:8081`
+- Prometheus on `http://localhost:9090`
+- Grafana on `http://localhost:3000`
+- Pact broker on `http://localhost:9292`
 
-<!-- GETTING STARTED -->
-## Getting Started
+If you prefer the raw compose command:
 
-This is an example of how you may give instructions on setting up your project locally.
-To get a local copy up and running follow these simple example steps.
+```bash
+docker compose --profile monolith up
+```
 
-### Prerequisites
+## Deterministic seed data
 
-This is an example of how to list things you need to use the software and how to install them.
+The monolith milestone uses deterministic demo entities from `internal/demo/spec.go`.
 
-* npm
+The seeded happy-path data includes:
 
-  ```sh
-  npm install npm@latest -g
-  ```
+- customer: `Demo Shopper`
+- stores:
+  - `Fresh Harvest Grocers`
+  - `Pantry Corner`
+- products used in the happy path:
+  - `Bananas` x2 at `6`
+  - `Rice 2kg` x1 at `18`
 
-### Installation
+Expected seeded basket total:
 
-1. Get a free API Key at [https://example.com](https://example.com)
-2. Clone the repo
+- `30`
 
-   ```sh
-   git clone https://github.com/github_username/repo_name.git
-   ```
+You do not need to hand-seed the database for normal monolith startup. For `@seeded-demo` end-to-end tests, the test suite reseeds the deterministic state automatically when run with `-mono`.
 
-3. Install NPM packages
+## Start the Angular kiosk
 
-   ```sh
-   npm install
-   ```
+Open a second terminal:
 
-4. Enter your API in `config.js`
+```bash
+cd client/soko-bora-web-app
+npm install
+npm start
+```
 
-   ```js
-   const API_KEY = 'ENTER YOUR API';
-   ```
+The Angular dev server runs on `http://localhost:4200` and proxies backend calls to `http://localhost:8080`.
 
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
+The app routes the main demo surface to `/kiosk`, and that route is protected. If you are not signed in, the frontend redirects you to `/sign-in` first and then returns you to the kiosk flow after authentication.
 
-<!-- USAGE EXAMPLES -->
-## Usage
+## Kiosk happy path
 
-Use this space to show useful examples of how a project can be used. Additional screenshots, code examples and demos work well in this space. You may also link to more resources.
+The current kiosk milestone supports the following customer-facing flow in the Angular UI:
 
-_For more examples, please refer to the [Documentation](https://example.com)_
+1. load the seeded demo customer and participating store catalog
+2. browse products from the seeded stores
+3. add and remove products from the live basket
+4. see basket totals update from backend basket state
+5. authorize payment and submit checkout
+6. refresh live order status from the backend search projection
 
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
+In other words, the kiosk is no longer a placeholder page. It is backed by real ConnectRPC calls into the monolith.
 
-<!-- ROADMAP -->
-## Roadmap
+## Manual demo walkthrough
 
-* [ ] Feature 1
-* [ ] Feature 2
-* [ ] Feature 3
-  * [ ] Nested Feature
+Once the monolith and Angular app are running:
 
-See the [open issues](https://github.com/owezzy/soko-bora-mngt-system/issues) for a full list of proposed features (and known issues).
+1. Open `http://localhost:4200`
+2. Navigate to the kiosk flow
+3. Add seeded products to the basket
+   - `Bananas`
+   - `Rice 2kg`
+4. Confirm the basket total reaches `30`
+5. Trigger checkout from the kiosk
+6. Watch the order-status panel read live order state from the backend search path
 
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
+The kiosk demonstrates the customer-side journey. The full cross-service completion proof, including depot progression, invoice payment, notifications, and final search projection, is covered by the automated seeded proof below.
 
-<!-- CONTRIBUTING -->
-## Contributing
+## Automated verification
 
-Contributions are what make the open source community such an amazing place to learn, inspire, and create. Any contributions you make are **greatly appreciated**.
+### Canonical milestone proof
 
-If you have a suggestion that would make this better, please fork the repo and create a pull request. You can also simply open an issue with the tag "enhancement".
-Don't forget to give the project a star! Thanks again!
+This is the single command that proves the seeded kiosk demo works end to end:
 
-1. Fork the Project
-2. Create your Feature Branch (`git checkout -b feature/AmazingFeature`)
-3. Commit your Changes (`git commit -m 'Add some AmazingFeature'`)
-4. Push to the Branch (`git push origin feature/AmazingFeature`)
-5. Open a Pull Request
+```bash
+go test -tags e2e ./testing/e2e/... -run TestEndToEnd -mono -godog.tags=@demo-milestone-proof
+```
 
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
+That focused proof runs the canonical seeded kiosk scenario in:
 
-<!-- LICENSE -->
+- `testing/e2e/features/kiosk/shopping.feature`
+
+It verifies the seeded journey through:
+
+- basket start
+- seeded item addition
+- payment authorization
+- checkout
+- order creation
+- depot shopping list lifecycle
+- invoice creation and payment
+- notification persistence
+- final search projection status
+
+### Seeded demo regression suite
+
+To run the broader seeded-demo scenarios:
+
+```bash
+go test -tags e2e ./testing/e2e/... -run TestEndToEnd -mono -godog.tags=@seeded-demo
+```
+
+### Frontend verification
+
+From `client/soko-bora-web-app`:
+
+```bash
+npm test -- --watch=false --browsers=ChromeHeadless
+npm run build
+```
+
+## Demo proof narrative
+
+The monolith-first proof covers these backend transitions:
+
+1. the seeded customer starts a basket
+2. seeded products are added
+3. checkout creates an approved order
+4. the create-order saga creates a depot shopping list
+5. fulfillment marks the order ready
+6. invoice payment completes the order
+7. search projects the final backend-visible status
+
+For extra detail, see:
+
+- `docs/monolith-happy-path.md`
+
+## Useful commands
+
+From the repository root:
+
+```bash
+make soko-bora
+go test ./...
+go test -tags e2e ./testing/e2e/... -mono
+go generate ./...
+```
+
+From `client/soko-bora-web-app`:
+
+```bash
+npm start
+npm test
+npm run build
+npm run generate
+```
+
+## Stop and clean up
+
+To stop the monolith stack:
+
+```bash
+docker compose --profile monolith down
+```
+
+To stop the stack and remove volumes with the repo's make target:
+
+```bash
+make clean-up-soko-bora
+```
+
+If you prefer the raw compose command for the same cleanup:
+
+```bash
+docker compose down -v
+```
+
 ## License
 
-Distributed under the MIT License. See `MIT-LICENSE.txt` for more information.
-
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
-
-<!-- CONTACT -->
-## Contact
-
-Owen Adirah - [@owen_adira](https://twitter.com/owen_adira) - <<owenadira@gmail.com>>
-
-Project Link: [https://github.com/owezzy/soko-bora-mngt-system](https://github.com/owezzy/soko-bora-mngt-system)
-
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
-
-<!-- ACKNOWLEDGMENTS -->
-## Acknowledgments
-
-* [Event-Driven Architecture in Golang](https://download.packt.com/free-ebook/9781803238012)
-* []()
-* []()
-
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
-
-<!-- MARKDOWN LINKS & IMAGES -->
-<!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->
-[contributors-shield]: https://img.shields.io/github/contributors/owezzy/soko-bora-mngt-system.svg?style=for-the-badge
-[contributors-url]: https://github.com/owezzy/soko-bora-mngt-system/graphs/contributors
-[forks-shield]: https://img.shields.io/github/forks/owezzy/soko-bora-mngt-system.svg?style=for-the-badge
-[forks-url]: https://github.com/owezzy/soko-bora-mngt-system/network/members
-[stars-shield]: https://img.shields.io/github/stars/owezzy/soko-bora-mngt-system.svg?style=for-the-badge
-[stars-url]: https://github.com/owezzy/soko-bora-mngt-system/stargazers
-[issues-shield]: https://img.shields.io/github/issues/owezzy/soko-bora-mngt-system.svg?style=for-the-badge
-[issues-url]: https://github.com/owezzy/soko-bora-mngt-system/issues
-[license-shield]: https://img.shields.io/github/license/owezzy/soko-bora-mngt-system.svg?style=for-the-badge
-[license-url]: https://github.com/owezzy/soko-bora-mngt-system/blob/main/MIT-LICENSE.txt
-[linkedin-shield]: https://img.shields.io/badge/-LinkedIn-black.svg?style=for-the-badge&logo=linkedin&colorB=555
-[linkedin-url]: https://linkedin.com/in/owezzy
-[product-screenshot]: internal/assets/High-level-application-components-view.png
-[Angular.io]: https://img.shields.io/badge/Angular-DD0031?style=for-the-badge&logo=angular&logoColor=white
-[Angular-url]: https://angular.io/
-[Golang]: https://img.shields.io/badge/go-%2300ADD8.svg?style=for-the-badge&logo=go&logoColor=white
-[Golang-url]: https://go.dev/
-
-[GraphQL]: https://img.shields.io/badge/-GraphQL-E10098?style=for-the-badge&logo=graphql&logoColor=white
-[Graphql-url]: https://graphql.org/
-
-[aws]: https://img.shields.io/badge/AWS-%23FF9900.svg?style=for-the-badge&logo=amazon-aws&logoColor=white
-[aws-url]: https://aws.amazon.com/
-
-[Git]: https://img.shields.io/badge/github-%23121011.svg?style=for-the-badge&logo=github&logoColor=white
-[git]: https://github.com/
+Distributed under the MIT License. See `MIT-LICENSE.txt`.


### PR DESCRIPTION
## Summary
- replace the template root README with a runnable monolith demo guide for the kiosk milestone
- document deterministic seed data, kiosk startup flow, manual walkthrough, and automated proof commands
- align cleanup and kiosk auth wording with the repo's actual Makefile and Angular route behavior

Closes #25