### PR TITLE
docs: add app workflow wireframe diagrams

### DIFF
--- a/docs/Diagrams/app_workflows_ui_screens.svg
+++ b/docs/Diagrams/app_workflows_ui_screens.svg
@@ -1,0 +1,115 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 9080.150000000001 1630" width="9080.150000000001" height="1630" style="--bg:#ffffff;--fg:#1f2328;--line:#d1d9e0;--accent:#0969da;--muted:#59636e;background:var(--bg)">
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;display=swap');
+  text { font-family: 'Inter', system-ui, sans-serif; }
+  svg {
+    /* Derived from --bg and --fg (overridable via --line, --accent, etc.) */
+    --_text:          var(--fg);
+    --_text-sec:      var(--muted, color-mix(in srgb, var(--fg) 60%, var(--bg)));
+    --_text-muted:    var(--muted, color-mix(in srgb, var(--fg) 40%, var(--bg)));
+    --_text-faint:    color-mix(in srgb, var(--fg) 25%, var(--bg));
+    --_line:          var(--line, color-mix(in srgb, var(--fg) 30%, var(--bg)));
+    --_arrow:         var(--accent, color-mix(in srgb, var(--fg) 50%, var(--bg)));
+    --_node-fill:     var(--surface, color-mix(in srgb, var(--fg) 3%, var(--bg)));
+    --_node-stroke:   var(--border, color-mix(in srgb, var(--fg) 20%, var(--bg)));
+    --_group-fill:    var(--bg);
+    --_group-hdr:     color-mix(in srgb, var(--fg) 5%, var(--bg));
+    --_inner-stroke:  color-mix(in srgb, var(--fg) 12%, var(--bg));
+    --_key-badge:     color-mix(in srgb, var(--fg) 10%, var(--bg));
+  }
+</style>
+<defs>
+  <marker id="arrowhead" markerWidth="8" markerHeight="4.8" refX="8" refY="2.4" orient="auto">
+    <polygon points="0 0, 8 2.4, 0 4.8" fill="var(--_arrow)" />
+  </marker>
+  <marker id="arrowhead-start" markerWidth="8" markerHeight="4.8" refX="0" refY="2.4" orient="auto-start-reverse">
+    <polygon points="8 0, 0 2.4, 8 4.8" fill="var(--_arrow)" />
+  </marker>
+</defs>
+<rect x="6504.435" y="40" width="991.2000000000005" height="268" rx="0" ry="0" fill="var(--_group-fill)" stroke="var(--_node-stroke)" stroke-width="1" />
+<rect x="6504.435" y="40" width="991.2000000000005" height="28" rx="0" ry="0" fill="var(--_group-hdr)" stroke="var(--_node-stroke)" stroke-width="1" />
+<text x="6516.435" y="54" dy="0.35em" font-size="12" font-weight="600" fill="var(--_text-sec)">&quot;🖥️ Boot &amp; Setup&quot;</text>
+<rect x="5199.56" y="352" width="3840.59" height="112" rx="0" ry="0" fill="var(--_group-fill)" stroke="var(--_node-stroke)" stroke-width="1" />
+<rect x="5199.56" y="352" width="3840.59" height="28" rx="0" ry="0" fill="var(--_group-hdr)" stroke="var(--_node-stroke)" stroke-width="1" />
+<text x="5211.56" y="366" dy="0.35em" font-size="12" font-weight="600" fill="var(--_text-sec)">&quot;🔐 Authentication Screens&quot;</text>
+<rect x="1005.665" y="525" width="7283.740000000002" height="892" rx="0" ry="0" fill="var(--_group-fill)" stroke="var(--_node-stroke)" stroke-width="1" />
+<rect x="1005.665" y="525" width="7283.740000000002" height="28" rx="0" ry="0" fill="var(--_group-hdr)" stroke="var(--_node-stroke)" stroke-width="1" />
+<text x="1017.665" y="539" dy="0.35em" font-size="12" font-weight="600" fill="var(--_text-sec)">&quot;🛒 Kiosk Screens&quot;</text>
+<rect x="40" y="681" width="945.664999999999" height="909" rx="0" ry="0" fill="var(--_group-fill)" stroke="var(--_node-stroke)" stroke-width="1" />
+<rect x="40" y="681" width="945.664999999999" height="28" rx="0" ry="0" fill="var(--_group-hdr)" stroke="var(--_node-stroke)" stroke-width="1" />
+<text x="52" y="695" dy="0.35em" font-size="12" font-weight="600" fill="var(--_text-sec)">&quot;⚙️ Backend Fulfillment (not UI — automated)&quot;</text>
+<rect x="859.7825000000003" y="352" width="4319.7775" height="112" rx="0" ry="0" fill="var(--_group-fill)" stroke="var(--_node-stroke)" stroke-width="1" />
+<rect x="859.7825000000003" y="352" width="4319.7775" height="28" rx="0" ry="0" fill="var(--_group-hdr)" stroke="var(--_node-stroke)" stroke-width="1" />
+<text x="871.7825000000003" y="366" dy="0.35em" font-size="12" font-weight="600" fill="var(--_text-sec)">&quot;👤 Admin/Setup Screens (documented in E2E)&quot;</text>
+<polyline points="7000.035000000001,132 7000.035000000001,252" fill="none" stroke="var(--_line)" stroke-width="0.75" marker-end="url(#arrowhead)" />
+<polyline points="7000.035000000001,288 7000.035000000001,408" fill="none" stroke="var(--_line)" stroke-width="0.75" marker-end="url(#arrowhead)" />
+<polyline points="7000.035000000001,444 7000.035000000001,599 7867.005000000001,599" fill="none" stroke="var(--_line)" stroke-width="0.75" marker-end="url(#arrowhead)" />
+<polyline points="8778.51,426 8888.36,426 8888.36,426 8910.33,426 8910.33,426 8778.51,426" fill="none" stroke="var(--_line)" stroke-width="0.75" stroke-dasharray="4 4" marker-end="url(#arrowhead)" />
+<polyline points="6274.430000000001,617 6274.430000000001,755 4405.555,755" fill="none" stroke="var(--_line)" stroke-width="0.75" marker-end="url(#arrowhead)" />
+<polyline points="3495.8050000000003,773 3495.8050000000003,893" fill="none" stroke="var(--_line)" stroke-width="0.75" marker-end="url(#arrowhead)" />
+<polyline points="3495.8050000000003,929 3495.8050000000003,1049" fill="none" stroke="var(--_line)" stroke-width="0.75" marker-end="url(#arrowhead)" />
+<polyline points="3495.8050000000003,1085 3495.8050000000003,1205" fill="none" stroke="var(--_line)" stroke-width="0.75" marker-end="url(#arrowhead)" />
+<polyline points="3495.8050000000003,1241 3495.8050000000003,1361" fill="none" stroke="var(--_line)" stroke-width="0.75" marker-end="url(#arrowhead)" />
+<polyline points="3495.8050000000003,1397 3495.8050000000003,1437 816.6700000000001,1437 816.6700000000001,1552 950.7999999999993,1552" fill="none" stroke="var(--_line)" stroke-width="0.75" stroke-dasharray="4 4" marker-end="url(#arrowhead)" />
+<polyline points="465.9499999999998,773 465.9499999999998,893" fill="none" stroke="var(--_line)" stroke-width="0.75" marker-end="url(#arrowhead)" />
+<polyline points="465.9499999999998,929 465.9499999999998,1049" fill="none" stroke="var(--_line)" stroke-width="0.75" marker-end="url(#arrowhead)" />
+<polyline points="465.9499999999998,1085 465.9499999999998,1105 527.8500000000004,1105 527.8500000000004,1205" fill="none" stroke="var(--_line)" stroke-width="0.75" marker-end="url(#arrowhead)" />
+<polyline points="527.8500000000004,1241 527.8500000000004,1361" fill="none" stroke="var(--_line)" stroke-width="0.75" marker-end="url(#arrowhead)" />
+<polyline points="465.9499999999998,1085 465.9499999999998,1105 404.0499999999993,1105 404.0499999999993,1552 537.2999999999996,1552" fill="none" stroke="var(--_line)" stroke-width="0.75" marker-end="url(#arrowhead)" />
+<polyline points="527.8500000000004,1397 527.8500000000004,1417 179.8249999999989,1417 179.8249999999989,1552 61.99999999999963,1552" fill="none" stroke="var(--_line)" stroke-width="0.75" marker-end="url(#arrowhead)" />
+<polyline points="465.9499999999998,1085 465.9499999999998,1105 651.6499999999996,1105 651.6499999999996,1552 561.2999999999993,1552" fill="none" stroke="var(--_line)" stroke-width="0.75" marker-end="url(#arrowhead)" />
+<polyline points="527.8500000000004,1397 527.8500000000004,1552 561.2999999999993,1552" fill="none" stroke="var(--_line)" stroke-width="0.75" marker-end="url(#arrowhead)" />
+<polyline points="4594.585,444 4594.585,599 4681.855000000001,599" fill="none" stroke="var(--_line)" stroke-width="0.75" stroke-dasharray="4 4" marker-end="url(#arrowhead)" />
+<polyline points="3173.8575,444 3173.8575,755 2586.0550000000003,755" fill="none" stroke="var(--_line)" stroke-width="0.75" stroke-dasharray="4 4" marker-end="url(#arrowhead)" />
+<polyline points="1737.9075000000003,444 1737.9075000000003,755 2586.0550000000003,755" fill="none" stroke="var(--_line)" stroke-width="0.75" stroke-dasharray="4 4" marker-end="url(#arrowhead)" />
+<rect x="6949.135000000001" y="499" width="101.8" height="27" rx="4" ry="4" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="0.5" />
+<text x="7000.035000000001" y="512.5" text-anchor="middle" dy="0.35em" font-size="11" font-weight="400" fill="var(--_text-muted)">&quot;authenticated&quot;</text>
+<rect x="8796.51" y="412.5" width="227.64000000000001" height="27" rx="4" ry="4" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="0.5" />
+<text x="8910.33" y="426" text-anchor="middle" dy="0.35em" font-size="11" font-weight="400" fill="var(--_text-muted)">&quot;not authenticated\n/ redirects here&quot;</text>
+<rect x="711.4300000000001" y="1452" width="210.48000000000002" height="27" rx="4" ry="4" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="0.5" />
+<text x="816.6700000000001" y="1465.5" text-anchor="middle" dy="0.35em" font-size="11" font-weight="400" fill="var(--_text-muted)">&quot;backend updates\nfeed live panel&quot;</text>
+<rect x="4503.645" y="499" width="181.88" height="27" rx="4" ry="4" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="0.5" />
+<text x="4594.585" y="512.5" text-anchor="middle" dy="0.35em" font-size="11" font-weight="400" fill="var(--_text-muted)">&quot;creates customer\nfor kiosk&quot;</text>
+<rect x="3085.7775" y="585.5" width="176.16" height="27" rx="4" ry="4" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="0.5" />
+<text x="3173.8575" y="599" text-anchor="middle" dy="0.35em" font-size="11" font-weight="400" fill="var(--_text-muted)">&quot;creates store\nfor catalog&quot;</text>
+<rect x="1644.1075000000003" y="585.5" width="187.6" height="27" rx="4" ry="4" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="0.5" />
+<text x="1737.9075000000003" y="599" text-anchor="middle" dy="0.35em" font-size="11" font-weight="400" fill="var(--_text-muted)">&quot;creates product\nfor catalog&quot;</text>
+<rect x="6551.460000000001" y="96" width="897.1500000000001" height="36" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+<rect x="6526.435" y="252" width="947.2" height="36" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+<rect x="5221.56" y="408" width="3556.9500000000003" height="36" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+<rect x="4681.855000000001" y="581" width="3185.15" height="36" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+<rect x="2586.0550000000003" y="737" width="1819.5000000000002" height="36" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+<rect x="2847.03" y="893" width="1297.5500000000002" height="36" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+<rect x="1763.805" y="1049" width="3464.0000000000005" height="36" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+<rect x="1896.0800000000002" y="1205" width="3199.4500000000003" height="36" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+<rect x="1102.4300000000003" y="1361" width="4786.75" height="36" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+<rect x="392.74999999999983" y="737" width="146.4" height="36" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+<rect x="249.7499999999998" y="893" width="432.40000000000003" height="36" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+<rect x="403.4749999999998" y="1049" width="124.95" height="36" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+<rect x="426.05000000000035" y="1205" width="203.60000000000002" height="36" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+<rect x="451.0750000000004" y="1361" width="153.55" height="36" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+<rect x="61.99999999999963" y="1534" width="475.3" height="36" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+<rect x="561.2999999999993" y="1534" width="389.50000000000006" height="36" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+<rect x="4031.61" y="408" width="1125.95" height="36" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+<rect x="2618.0325000000003" y="408" width="1111.65" height="36" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+<rect x="881.7825000000001" y="408" width="1712.2500000000002" height="36" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+<text x="7000.035000000001" y="114" text-anchor="middle" dy="0.35em" font-size="13" font-weight="500" fill="var(--_text)">&quot;Terminal: make soko-bora\n━━━━━━━━━━━━━━━━━━━━\n$ make soko-bora\n\nMonolith starts on :8080\nPostgres, NATS, Jaeger...&quot;</text>
+<text x="7000.035000000001" y="270" text-anchor="middle" dy="0.35em" font-size="13" font-weight="500" fill="var(--_text)">&quot;Terminal: npm start\n━━━━━━━━━━━━━━━━━━━━\n$ cd client/soko-bora-web-app\n$ npm install &amp;&amp; npm start\n\nAngular kiosk on :4200&quot;</text>
+<text x="7000.035000000001" y="426" text-anchor="middle" dy="0.35em" font-size="13" font-weight="500" fill="var(--_text)">&quot;┌─────────────────────────┐\n│     SIGN IN             │\n│                         │\n│  ┌───────────────────┐  │\n│  │ Email             │  │\n│  └───────────────────┘  │\n│  ┌───────────────────┐  │\n│  │ Password          │  │\n│  └───────────────────┘  │\n│                         │\n│  ┌───────────────────┐  │\n│  │    Sign In ►      │  │\n│  └───────────────────┘  │\n│                         │\n│  Forgot password?       │\n│  Create account         │\n└─────────────────────────┘&quot;</text>
+<text x="6274.430000000001" y="599" text-anchor="middle" dy="0.35em" font-size="13" font-weight="500" fill="var(--_text)">&quot;┌─────────────────────────────────┐\n│  KIOSK HOME                     │\n│  Customer: Demo Shopper         │\n│━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━│\n│  Stores:                        │\n│  • Fresh Harvest Grocers        │\n│  • Pantry Corner                │\n│                                 │\n│  ┌──────────┐ ┌──────────┐     │\n│  │ Browse ► │ │ Basket 🛒│     │\n│  └──────────┘ └──────────┘     │\n└─────────────────────────────────┘&quot;</text>
+<text x="3495.8050000000003" y="755" text-anchor="middle" dy="0.35em" font-size="13" font-weight="500" fill="var(--_text)">&quot;┌─────────────────────────────────┐\n│  PRODUCT CATALOG                │\n│  Store: Fresh Harvest Grocers   │\n│━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━│\n│                                 │\n│  ┌─────────────────────────┐    │\n│  │ Bananas         $6  [+</text>
+<text x="3495.8050000000003" y="911" text-anchor="middle" dy="0.35em" font-size="13" font-weight="500" fill="var(--_text)">&quot;┌─────────────────────────────────┐\n│  BASKET                         │\n│━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━│\n│                                 │\n│  Bananas    x2   $12    [−</text>
+<text x="3495.8050000000003" y="1067" text-anchor="middle" dy="0.35em" font-size="13" font-weight="500" fill="var(--_text)">&quot;┌─────────────────────────────────┐\n│  PAYMENT AUTHORIZATION          │\n│━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━│\n│                                 │\n│  Amount: $30                    │\n│  Customer: Demo Shopper         │\n│                                 │\n│  Status: ✅ Authorized          │\n│                                 │\n│  ┌──────────────────────────┐   │\n│  │      Checkout ►          │   │\n│  └──────────────────────────┘   │\n└─────────────────────────────────┘&quot;</text>
+<text x="3495.8050000000003" y="1223" text-anchor="middle" dy="0.35em" font-size="13" font-weight="500" fill="var(--_text)">&quot;┌─────────────────────────────────┐\n│  CHECKOUT COMPLETE              │\n│━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━│\n│                                 │\n│  ✅ Order submitted!            │\n│                                 │\n│  Order created via backend saga │\n│                                 │\n│  ┌──────────────────────────┐   │\n│  │   View Order Status ►    │   │\n│  └──────────────────────────┘   │\n└─────────────────────────────────┘&quot;</text>
+<text x="3495.8050000000003" y="1379" text-anchor="middle" dy="0.35em" font-size="13" font-weight="500" fill="var(--_text)">&quot;┌─────────────────────────────────┐\n│  ORDER STATUS (Live)            │\n│━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━│\n│                                 │\n│  Order: #ORD-xxxx               │\n│  Items: Bananas x2, Rice x1     │\n│                                 │\n│  Status Timeline:               │\n│  ● Approved                     │\n│  ● Ready For Pickup ← current  │\n│  ○ Completed                    │\n│                                 │\n│  ┌──────────────────────────┐   │\n│  │      Refresh ↻           │   │\n│  └──────────────────────────┘   │\n│                                 │\n│  (search projection updates)    │\n└─────────────────────────────────┘&quot;</text>
+<text x="465.9499999999998" y="755" text-anchor="middle" dy="0.35em" font-size="13" font-weight="500" fill="var(--_text)">&quot;Order Approved&quot;</text>
+<text x="465.9499999999998" y="911" text-anchor="middle" dy="0.35em" font-size="13" font-weight="500" fill="var(--_text)">&quot;Depot: Shopping List\navailable → assigned → completed&quot;</text>
+<text x="465.9499999999998" y="1067" text-anchor="middle" dy="0.35em" font-size="13" font-weight="500" fill="var(--_text)">&quot;Order Ready&quot;</text>
+<text x="527.8500000000004" y="1223" text-anchor="middle" dy="0.35em" font-size="13" font-weight="500" fill="var(--_text)">&quot;Invoice Created → Paid&quot;</text>
+<text x="527.8500000000004" y="1379" text-anchor="middle" dy="0.35em" font-size="13" font-weight="500" fill="var(--_text)">&quot;Order Completed&quot;</text>
+<text x="299.64999999999964" y="1552" text-anchor="middle" dy="0.35em" font-size="13" font-weight="500" fill="var(--_text)">&quot;Notifications:\n• ready notification\n• created notification&quot;</text>
+<text x="756.0499999999993" y="1552" text-anchor="middle" dy="0.35em" font-size="13" font-weight="500" fill="var(--_text)">&quot;Search Projection:\nReady For Pickup → Completed&quot;</text>
+<text x="4594.585" y="426" text-anchor="middle" dy="0.35em" font-size="13" font-weight="500" fill="var(--_text)">&quot;┌────────────────────────┐\n│  REGISTER CUSTOMER     │\n│  ┌──────────────────┐  │\n│  │ Name             │  │\n│  └──────────────────┘  │\n│  [Register</text>
+<text x="3173.8575" y="426" text-anchor="middle" dy="0.35em" font-size="13" font-weight="500" fill="var(--_text)">&quot;┌────────────────────────┐\n│  CREATE STORE          │\n│  ┌──────────────────┐  │\n│  │ Store Name       │  │\n│  └──────────────────┘  │\n│  [Create</text>
+<text x="1737.9075000000003" y="426" text-anchor="middle" dy="0.35em" font-size="13" font-weight="500" fill="var(--_text)">&quot;┌────────────────────────┐\n│  CREATE PRODUCT        │\n│  ┌──────────────────┐  │\n│  │ Product Name     │  │\n│  └──────────────────┘  │\n│  ┌──────────────────┐  │\n│  │ Price            │  │\n│  └──────────────────┘  │\n│  [Create</text>
+</svg>

--- a/docs/Diagrams/app_workflows_wireframe.puml
+++ b/docs/Diagrams/app_workflows_wireframe.puml
@@ -1,0 +1,141 @@
+@startuml
+!theme plain
+skinparam dpi 300
+skinparam defaultFontName Jetbrains Mono
+skinparam shadowing false
+skinparam linetype ortho
+top to bottom direction
+
+title MallBots App Workflow Wireframe
+
+rectangle "Boot & Demo Setup" as boot {
+  rectangle "Start monolith\nmake soko-bora" as start_monolith
+  rectangle "Seed deterministic demo data\nDemo Shopper\nFresh Harvest Grocers\nPantry Corner" as seed_demo
+  rectangle "Start Angular kiosk\nnpm start" as start_kiosk
+}
+
+rectangle "Auth Entry Flow" as auth {
+  rectangle "Open app\n/ redirects to /kiosk" as open_app
+  rectangle "Auth guard check" as guard_check
+  rectangle "Sign in" as sign_in
+  rectangle "Redirect to /kiosk" as signed_in_redirect
+}
+
+rectangle "Primary Kiosk Journey" as kiosk {
+  rectangle "Kiosk home\nload customer + store catalog" as kiosk_home
+  rectangle "Browse products" as browse_products
+  rectangle "Add items to basket" as add_items
+  rectangle "Remove items from basket" as remove_items
+  rectangle "View basket snapshot\nsee running total" as basket_snapshot
+  rectangle "Authorize payment" as authorize_payment
+  rectangle "Checkout basket" as checkout_basket
+  rectangle "Order submitted" as order_submitted
+  rectangle "Refresh order status" as refresh_order
+  rectangle "Live status panel\nApproved -> Ready For Pickup -> Completed" as live_status
+  rectangle "Product lookup error\nproduct was not located" as product_error
+}
+
+rectangle "Backend Order & Fulfillment Flow" as backend {
+  rectangle "Basket started" as basket_started
+  rectangle "Items persisted" as items_persisted
+  rectangle "Payment record created\nstatus: authorized" as payment_record
+  rectangle "Create-order saga" as create_order_saga
+  rectangle "Order exists\nstatus: approved" as approved_order
+  rectangle "Depot shopping list\nstatus: available" as shopping_list_available
+  rectangle "Assign to bot\ndemo-bot-001" as assign_bot
+  rectangle "Shopping list\nstatus: assigned" as shopping_list_assigned
+  rectangle "Complete shopping list" as complete_list
+  rectangle "Shopping list\nstatus: completed" as shopping_list_completed
+  rectangle "Order status: ready" as ready_order
+  rectangle "Invoice created" as invoice_created
+  rectangle "Pay invoice" as pay_invoice
+  rectangle "Invoice paid" as invoice_paid
+  rectangle "Order completed" as completed_order
+}
+
+rectangle "Notifications & Search Projection" as projections {
+  rectangle "\"ready\" notification persisted" as ready_notification
+  rectangle "Search projection\nReady For Pickup" as ready_projection
+  rectangle "\"created\" notification persisted" as created_notification
+  rectangle "Search projection\nCompleted" as completed_projection
+}
+
+rectangle "Documented Setup/Admin Flows" as admin {
+  rectangle "Register customer" as register_customer
+  rectangle "Create store" as create_store
+  rectangle "Create product" as create_product
+}
+
+start_monolith --> seed_demo
+seed_demo --> start_kiosk
+start_kiosk --> open_app
+
+open_app --> guard_check
+guard_check --> sign_in : not authenticated
+sign_in --> signed_in_redirect
+guard_check --> signed_in_redirect : authenticated
+signed_in_redirect --> kiosk_home
+
+kiosk_home --> browse_products
+browse_products --> add_items
+add_items --> basket_snapshot
+browse_products --> product_error : product missing
+add_items --> remove_items
+remove_items --> basket_snapshot
+basket_snapshot --> authorize_payment
+authorize_payment --> checkout_basket
+checkout_basket --> order_submitted
+order_submitted --> refresh_order
+refresh_order --> live_status
+
+checkout_basket --> basket_started
+basket_started --> items_persisted
+items_persisted --> payment_record
+payment_record --> create_order_saga
+create_order_saga --> approved_order
+approved_order --> shopping_list_available
+shopping_list_available --> assign_bot
+assign_bot --> shopping_list_assigned
+shopping_list_assigned --> complete_list
+complete_list --> shopping_list_completed
+shopping_list_completed --> ready_order
+ready_order --> invoice_created
+invoice_created --> pay_invoice
+pay_invoice --> invoice_paid
+invoice_paid --> completed_order
+
+ready_order --> ready_notification
+ready_order --> ready_projection
+ready_projection --> live_status
+invoice_paid --> created_notification
+invoice_paid --> completed_projection
+completed_projection --> live_status
+
+register_customer --> kiosk_home
+create_store --> browse_products
+create_product --> browse_products
+
+note right of auth
+  Documented routes:
+  - / -> /kiosk
+  - unauthenticated users go to /sign-in
+  - successful sign-in returns to kiosk
+end note
+
+note right of kiosk
+  Customer-visible wireframe path from README:
+  browse -> basket -> authorize payment -> checkout ->
+  refresh live order status
+end note
+
+note right of backend
+  Backed by baskets, ordering, depot,
+  payments, notifications, and search.
+end note
+
+note bottom of admin
+  These flows are documented in E2E features,
+  but are not part of the seeded kiosk happy path.
+end note
+
+@enduml


### PR DESCRIPTION
## Summary
- Adds PlantUML source (`app_workflows_wireframe.puml`) covering all documented monolith workflows
- Adds UI-screen-oriented SVG version (`app_workflows_ui_screens.svg`) for quick visual reference
- Covers: boot/setup, auth, kiosk journey, backend saga, projections, admin, and error paths

Closes #17